### PR TITLE
Adds templates for running Mender application in OpenShift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ frontend/Dockerfile
 docker-compose.yml
 api/init.sh
 api/wait-for-it.sh
+
+# Secrets generated for Mender
+keys-generated
+.key

--- a/mender/openshift/README.md
+++ b/mender/openshift/README.md
@@ -1,0 +1,99 @@
+# Mender + OpenShift
+## About
+The files in this directory provide everything required to utilize Mender in an OpenShift environment.
+
+This document outlines different details of the application.
+
+### Setting Up in OpenShift
+Follow the [quickstart guide](mender_deployment_quickstart.md) for exact steps for setup Mender in OpenShift. 
+
+## Certificates and Keys
+More detail outlining the certs and keys requirements of the system can be found in the [Mender documentation](https://docs.mender.io/1.7/administration/certificates-and-keys).
+
+### Certs
+Mender Clients (i.e. raspberry pi) require SSL authentication for communicating with the Mender application (both for the `mender-api-gateway` and `minio` components). 
+
+In a fully Docker Compose version of the application, SSL termination happens in the containers themselves (`mender-api-gateway` and a container called `storage-proxy`--which is not used with OpenShift).
+
+However, with OpenShift, SSL termination happens at the `Router`. Because of this, the `nginx.conf` for `mender-api-gateway` has been modified to remove SSL termination inside the container. This allows the unencrypted traffic from the `route` to arrive at the `service` and function correctly. This modification is achieved during the `ImageBuild` stage for the `mender-api-gateway`. `minio`, on the other hand, comes already configured to handle SSL termination at the router.
+
+Because the certs used by the `pathfinder.gov.bc.ca` are backed by a Certificate Authority, there is no added requirement for Mender Clients (PIs) to have copies of the public parts of the certificate since these are provided automatically (through the magic of the Internet). It is important to note that in this configuration Mender Clients need `ca-certificates` installed.
+
+### Keys
+There are two components in the Mender application--`mender-useradm` and `mender-device-auth`--which use RSA keys to sign their work.
+
+The keys should be generated with `rsa_keygen.sh` and stored for the lifetime of the application. This utility is based on [this tool](https://github.com/mendersoftware/integration/blob/master/keygen) from the Mender Integration git repo.
+
+The [quickstart guide](mender_deployment_quickstart.md) shows how to generate the keys and use them as input parameters for the related Mender templates. These keys become secrets--`mender-device-auth-key-secret` and `mender-useradm-key-secret`--in the application and are used by the appropriate components.
+
+## User Accounts
+User accounts for the `mender-Gui` are handled by the `mender-useradm` service.
+
+A username and password can be added by running:
+
+```
+/usr/bin/useradm create-user --username=<username> --password=<password>
+```
+from within a `mender-useradm` `pod`.
+
+The way the OpenShift implementation is structured, a default *username* is added as a template parameter with a *password* which is automatically generated. This *username* and *password* become an OpenShift secret--`mender-login-secret`. This process is outlined in the [quickstart guide](mender_deployment_quickstart.md).
+
+## Application Components
+The Mender application consists of 11 components. A sizable amount of information--albeit incomplete--about each of these components can be found in the [Mender Integration](https://github.com/mendersoftware/integration) git repo.
+
+These components have been broken down into "sub-applications"--each having its own template--and are explained blow.
+
+### Mender-Frontend
+This sub-application provides all the interface components for the application.
+
+#### Mender-API-Gateway
+The role of this component is to act as an entrypoint for all HTTP communication with Mender. Its main responsibility is the proxying of requests to other Mender components, while rewriting URLs from a public API scheme to an internal one.
+
+More details: [mender-api-gateway git](https://github.com/mendersoftware/mender-api-gateway-docker)
+
+#### Mender Gui
+The `mender-gui` component lives inside the application but is served via the `mender-gateway-api` component. 
+
+The role of this component is to provide a GUI web page for interacting with the Mender application.
+
+More details: [mender-gui git](https://github.com/mendersoftware/gui)
+
+### Mender-Component
+#### mender-deployments
+The role of this component is to manage artifacts, deployments, and reports of outcome of deployments.
+
+More details: [mender-deployments git](https://github.com/mendersoftware/deployments)
+
+#### mender-inventory
+The role of this component is to keep track of all clients in the system.  It stores attributes about devices reported by Mender clients, and supports searching and sorting of attributes.
+
+More details: [mender-inventory git](https://github.com/mendersoftware/inventory)
+
+#### mender-device-auth
+The role of this component is to handle issuing, maintaining and verifying JWT authentication tokens used by devices in Mender API calls. In essence, it handles all Client authentication for the whole application.
+
+More details: [mender-device-auth git](https://github.com/mendersoftware/deviceauth)
+
+#### mender-useradm
+The role of this component is to handle all user management and authentication of the system (e.g. add/remove users, login, etc).
+
+More details: [mender-useradm git](https://github.com/mendersoftware/useradm)
+
+### Mender-Mongodb
+This sub-application is a single component, Mongodb. Every service in the `Mender-Component` sub-application use this database to persist state.
+
+**Note**: This component is an unmodified Mongodb instance.
+
+### Mender-Conductor
+This sub-application is named after the main component underlying it--`mender-conductor`. This component is responsible for handling API requests which target multiple application components. In other words, when the `mender-api-gateway` needs to communicate with multiple components, it does it through `mender-conductor`.
+
+The other two components in this sub-application are `mender-redis` and `mender-elasticsearch`. These components allow `mender-conductor` to do its job and are not used by any other components (hence their existence in a sub-application). However it is unclear exactly what their role is.
+
+If `mender-conductor` is removed, much of the application will still function, however errors will show up in the GUI and it will not be possible to decommission devices.
+
+**Note**: `mender-conductor` is really covered in the Mender Integration](https://github.com/mendersoftware/integration) git repo.
+
+### Minio
+This sub-application consists of one component--`minio`. This component comes unmodified from the [BCDevOps](https://github.com/BCDevOps/minio-openshift) git repo. Because of this, it shows up as a separate application from `mender`.
+
+`minio` is effectively a clone of the Amazon S3 Bucket system. In the Mender application, the `mender-deployments` component is the only system which directly interacts with `minio`. It uses `minio` to store artifacts as well as provide Clients with URLs for downloading artifacts.

--- a/mender/openshift/mender_deployment_quickstart.md
+++ b/mender/openshift/mender_deployment_quickstart.md
@@ -1,0 +1,123 @@
+# Mender + OpenShift Quickstart
+## About
+This document provides every command required for get Mender running in OpenShift.
+
+**Note**: Be sure to set all ENV variables before running any of the other commands.
+
+## Step 1 - Setup Project ENV Variables
+The ENV are used to configure the deployment. Not all of them are strictly necessary since the `parameters` in templates have default values. However, the default values are not definitive best choices.
+
+```
+TOOLS_WORKSPACE=<your tools location>
+PROJECTNAME=<your deployment location>
+IMAGESTREAM_TAG=<dev|prod>
+MENDER_DEFAULT_USERNAME=<default username email address>
+MINIO_VOLUME_CAPACITY=<some volume capacity>
+MONGO_VOLUME_CAPACITY=<some volume capacity>
+REDIS_VOLUME_CAPACITY=<some volume capacity>
+ELASTICSEARCH_VOLUME_CAPACITY=<some volume capacity>
+MINIO_ROUTE_HOSTNAME=<s3mender.pathfinder.gov.bc.ca | s3mender-dev.pathfinder.gov.bc.ca>
+API_GATEWAY_ROUTE_HOSTNAME=<mender.pathfinder.gov.bc.ca | mender-dev.pathfinder.gov.bc.ca> 
+```
+
+## Step 2 - Generate Keys for `mender-useradm` and `mender-deviceauth`
+A handy key generator script handles generation of the two keys needed for this project.
+
+```
+cd queue-management/mender/openshift
+./rsa_keygen.sh
+```
+**NOTE**: do not commit files generated from this step to git
+
+Store generated keys as `ENV` variables for later use:
+
+```
+USERADM_KEY="$(cat ./keys-generated/keys/useradm/private.key)"
+DEVICEAUTH_KEY="$(cat ./keys-generated/keys/deviceauth/private.key)"
+```
+
+## Step 3 - Add ImageBuild and ImageStreams to Tools Space
+All the ImageBuild and ImageStreams are handled by a single template. All ImageStreams are initially tagged as `latest` and are--in later steps--tagged depending on which deployment context is desired.
+
+**Note**: Make sure to set the `TOOLS_WORKSPACE` ENV before running this command.
+
+```
+oc process -f ./templates/mender-image-build-template.yaml | oc create -n $TOOLS_WORKSPACE -f -
+```
+
+## Step 4 - Deploy Minio (BCDevOps Version)
+The following command creates an instance of the `minio` DeploymentConfig from the BCDevOps git repo. Unfortunatelly, the `app` tag is automatically set to `minio` (instead of `mender`) so this component will show up as an independent application. Mender will ahve no problem communicating with it.
+
+```
+oc process \
+    -f https://raw.githubusercontent.com/BCDevOps/minio-openshift/master/openshift/minio-deployment.json \
+    -p IMAGESTREAM_NAMESPACE=bcgov \
+    -p IMAGESTREAM_TAG=v1-latest \
+    -p VOLUME_CAPACITY=${MINIO_VOLUME_CAPACITY} | oc create -n $PROJECTNAME -f -
+```
+
+## Step 5 - Deploy Mender
+### mender-mongodb
+```
+oc process -f ./templates/mender-mongodb-deployment-template.yaml \
+    -p IMAGESTREAM_TAG=${IMAGESTREAM_TAG} \
+    -p TOOLS_WORKSPACE=${TOOLS_WORKSPACE} \
+    -p MONGO_VOLUME_CAPACITY=${MONGO_VOLUME_CAPACITY} | oc create -n $PROJECTNAME -f -
+```
+
+### mender-conductor
+```
+oc process -f ./templates/mender-conductor-deployment-template.yaml \
+    -p IMAGESTREAM_TAG=${IMAGESTREAM_TAG} \
+    -p TOOLS_WORKSPACE=${TOOLS_WORKSPACE} \
+    -p REDIS_VOLUME_CAPACITY=${REDIS_VOLUME_CAPACITY} \
+    -p ELASTICSEARCH_VOLUME_CAPACITY=${ELASTICSEARCH_VOLUME_CAPACITY} | oc create -n $PROJECTNAME -f -
+```
+
+### mender-components (core services)
+```
+oc process -f ./templates/mender-component-deployment-template.yaml \
+    -p IMAGESTREAM_TAG=${IMAGESTREAM_TAG} \
+    -p TOOLS_WORKSPACE=${TOOLS_WORKSPACE} \
+    -p MINIO_ROUTE_HOSTNAME=${MINIO_ROUTE_HOSTNAME} \
+    -p USERADM_KEY=${USERADM_KEY} \
+    -p DEVICEAUTH_KEY=${DEVICEAUTH_KEY} \
+    -p MENDER_DEFAULT_USERNAME=${MENDER_DEFAULT_USERNAME} | oc create -n $PROJECTNAME -f -
+```
+
+### mender-frontend (gatway and gui)
+```
+oc process -f ./templates/mender-frontend-deployment-template.yaml \
+    -p API_GATEWAY_ROUTE_HOSTNAME=${API_GATEWAY_ROUTE_HOSTNAME} \
+    -p TOOLS_WORKSPACE=${TOOLS_WORKSPACE} \
+    -p IMAGESTREAM_TAG=${IMAGESTREAM_TAG} | oc create -n $PROJECTNAME -f -
+```
+
+## Step 6 - Tag ImageStreams in Sequence to Bring Them Up
+These steps likely can be done all at once but have only been tested in sequence. It is likely best to wait after each step to make sure all systems are ready before tagging the next set of ImageStreams.
+
+### mender-conductor
+```
+oc tag -n ${TOOLS_WORKSPACE} mender-redis-stream:latest mender-redis-stream:${IMAGESTREAM_TAG}
+oc tag -n ${TOOLS_WORKSPACE} mender-elasticsearch-stream:latest mender-elasticsearch-stream:${IMAGESTREAM_TAG}
+oc tag -n ${TOOLS_WORKSPACE} mender-conductor-stream:latest mender-conductor-stream:${IMAGESTREAM_TAG}
+```
+
+### mender-mongodb
+```
+oc tag -n ${TOOLS_WORKSPACE} mender-mongodb-stream:latest mender-mongodb-stream:${IMAGESTREAM_TAG}
+```
+
+### mender-components
+```
+oc tag -n ${TOOLS_WORKSPACE} mender-inventory-stream:latest mender-inventory-stream:${IMAGESTREAM_TAG}
+oc tag -n ${TOOLS_WORKSPACE} mender-deployments-stream:latest mender-deployments-stream:${IMAGESTREAM_TAG}
+oc tag -n ${TOOLS_WORKSPACE} mender-device-auth-stream:latest mender-device-auth-stream:${IMAGESTREAM_TAG}
+oc tag -n ${TOOLS_WORKSPACE} mender-useradm-stream:latest mender-useradm-stream:${IMAGESTREAM_TAG}
+```
+
+### mender-frontend (gatway and gui)
+```
+oc tag -n ${TOOLS_WORKSPACE} mender-gui-stream:latest mender-gui-stream:${IMAGESTREAM_TAG}
+oc tag -n ${TOOLS_WORKSPACE} mender-api-gateway-stream:latest mender-api-gateway-stream:${IMAGESTREAM_TAG}
+```

--- a/mender/openshift/rsa_keygen.sh
+++ b/mender/openshift/rsa_keygen.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Borrowed from https://github.com/mendersoftware/integration/blob/master/keygen
+# generate keys for signing JSON Web Tokens
+ROOTDIR=$(pwd)/keys-generated
+KEYDIR=$ROOTDIR/keys
+FILE_NAME_PRIVATE_KEY="private.key"
+
+mkdir -p "$KEYDIR"
+cd "$KEYDIR"
+
+for DIR in deviceauth useradm
+do
+  mkdir $DIR
+  (
+    cd $DIR
+    openssl genpkey -algorithm RSA -out $FILE_NAME_PRIVATE_KEY -pkeyopt rsa_keygen_bits:3072
+
+    # convert to RSA private key format, otherwise services complain:"
+    # level=fatal msg="failed to read rsa private key: jwt: can't open key - not an rsa private key" file=proc.go func=runtime.main line=183
+    openssl rsa -in $FILE_NAME_PRIVATE_KEY -out $FILE_NAME_PRIVATE_KEY
+  )
+done

--- a/mender/openshift/templates/mender-conductor-deployment-template.yaml
+++ b/mender/openshift/templates/mender-conductor-deployment-template.yaml
@@ -1,0 +1,382 @@
+kind: Template
+apiVersion: v1
+labels:
+  template: "mender-conductor-deployment" 
+  app: mender
+  subapp: mender-conductor
+metadata:
+  name: mender-conductor-deployment
+objects:
+  # Mender-Conductor 
+  ## used by API-Gatway to communicate to multiple services simultaneously
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: mender-conductor
+      labels:
+        app: mender
+        subapp: mender-conductor
+    spec:
+      ports:
+      - port: 8080
+        protocol: TCP
+      selector:
+        service: mender-conductor
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: "The mender-conductor used by API-Gatway to communicate to multiple services simultaneously."
+        template.alpha.openshift.io/wait-for-ready: "true" #?
+      name: mender-conductor
+      labels:
+        app: mender
+        subapp: mender-conductor
+    spec:
+      replicas: 1
+      selector:
+        app: mender
+        service: mender-conductor
+      strategy:
+        type: Rolling
+        rollingParams:
+          updatePeriodSeconds: 1
+          intervalSeconds: 1
+          timeoutSeconds: 120
+          maxSurge: 2
+          maxUnavailable: 1
+        resources: {}
+        activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app: mender
+            service: mender-conductor
+            subapp: mender-conductor
+        spec:
+          containers:
+            - name: mender-conductor
+              image: " "
+              env:
+                - name: CONFIG_PROP
+                  value: "config.properties"
+                - name: CONDUCTOR_JAVA_OPTS
+                  value: "-Xms128m -Xmx128m"
+              # readinessProbe:
+              #   failureThreshold: 3
+              #   initialDelaySeconds: 3
+              #   periodSeconds: 10
+              #   successThreshold: 1
+              #   tcpSocket:
+              #     port: 8080
+              #   timeoutSeconds: 3
+              # livenessProbe:
+              #   failureThreshold: 3
+              #   initialDelaySeconds: 3
+              #   periodSeconds: 10
+              #   successThreshold: 1
+              #   tcpSocket:
+              #     port: 8080
+              #   timeoutSeconds: 3
+              terminationMessagePath: "/dev/termination-log"
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          schedulerName: default-scheduler
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: name
+                        operator: In
+                        values:
+                          - mender-conductor
+                  topologyKey: kubernetes.io/hostname
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - mender-conductor
+            from:
+              kind: ImageStreamTag
+              namespace: "${TOOLS_WORKSPACE}"
+              name: mender-conductor-stream:${IMAGESTREAM_TAG}
+
+  # Mender-Redis 
+  ## used by Mender-Conductor
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: mender-redis
+      labels:
+        app: mender
+        subapp: mender-conductor
+    spec:
+      ports:
+      - port: 6379
+        protocol: TCP
+      selector:
+        service: mender-redis
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: "The mender-redis used by Mender-Conductor."
+        template.alpha.openshift.io/wait-for-ready: "true" #?
+      name: mender-redis
+      labels:
+        app: mender
+        subapp: mender-conductor
+    spec:
+      replicas: 1
+      selector:
+        app: mender
+        service: mender-redis
+      strategy:
+        type: Rolling
+        rollingParams:
+          updatePeriodSeconds: 1
+          intervalSeconds: 1
+          timeoutSeconds: 240
+          maxSurge: 2
+          maxUnavailable: 1
+        resources: {}
+        activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app: mender
+            service: mender-redis
+            subapp: mender-conductor
+        spec:
+          containers:
+            - name: mender-redis
+              image: " "
+              command:
+                - /redis/entrypoint.sh
+              # readinessProbe:
+              #   failureThreshold: 3
+              #   initialDelaySeconds: 3
+              #   periodSeconds: 10
+              #   successThreshold: 1
+              #   tcpSocket:
+              #     port: 6379
+              #   timeoutSeconds: 3
+              # livenessProbe:
+              #   failureThreshold: 3
+              #   initialDelaySeconds: 3
+              #   periodSeconds: 10
+              #   successThreshold: 1
+              #   tcpSocket:
+              #     port: 6379
+              #   timeoutSeconds: 3
+              volumeMounts:
+                - name: mender-redis-pv-claim
+                  mountPath: /var/lib/redis
+              terminationMessagePath: "/dev/termination-log"
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 256Mi
+                limits:
+                  cpu: 1000m
+                  memory: 512Mi
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          schedulerName: default-scheduler
+          volumes:
+            - name: mender-redis-pv-claim
+              persistentVolumeClaim:
+                claimName: mender-redis-pv-claim
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: name
+                        operator: In
+                        values:
+                          - mender-redis
+                  topologyKey: kubernetes.io/hostname
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - mender-redis
+            from:
+              kind: ImageStreamTag
+              namespace: "${TOOLS_WORKSPACE}"
+              name: mender-redis-stream:${IMAGESTREAM_TAG}
+
+  # Mender-Elasticsearch 
+  ## used by Mender-Conductor
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: mender-elasticsearch
+      labels:
+        app: mender
+        subapp: mender-conductor
+    spec:
+      ports:
+      - port: 8080
+        protocol: TCP
+      selector:
+        service: mender-elasticsearch
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: "The mender-elasticsearch used by Mender-Conductor."
+        template.alpha.openshift.io/wait-for-ready: "true" #?
+      name: mender-elasticsearch
+      labels:
+        app: mender
+        subapp: mender-conductor
+    spec:
+      replicas: 1
+      selector:
+        app: mender
+        service: mender-elasticsearch
+      strategy:
+        type: Rolling
+        rollingParams:
+          updatePeriodSeconds: 1
+          intervalSeconds: 1
+          timeoutSeconds: 120
+          maxSurge: 2
+          maxUnavailable: 1
+        resources: {}
+        activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app: mender
+            subapp: mender-conductor
+            service: mender-elasticsearch
+        spec:
+          containers:
+            - name: mender-elasticsearch
+              image: " "
+              # readinessProbe:
+              #   failureThreshold: 3
+              #   initialDelaySeconds: 3
+              #   periodSeconds: 10
+              #   successThreshold: 1
+              #   tcpSocket:
+              #     port: 8080
+              #   timeoutSeconds: 3
+              # livenessProbe:
+              #   failureThreshold: 3
+              #   initialDelaySeconds: 3
+              #   periodSeconds: 10
+              #   successThreshold: 1
+              #   tcpSocket:
+              #     port: 8080
+              #   timeoutSeconds: 3
+              volumeMounts:
+                  - name: mender-elasticsearch-pv-claim
+                    mountPath: /usr/share/elasticsearch/data
+              terminationMessagePath: "/dev/termination-log"
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          schedulerName: default-scheduler
+          volumes:
+              - name: mender-elasticsearch-pv-claim
+                persistentVolumeClaim:
+                  claimName: mender-elasticsearch-pv-claim
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: name
+                        operator: In
+                        values:
+                          - mender-elasticsearch
+                  topologyKey: kubernetes.io/hostname
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - mender-elasticsearch
+            from:
+              kind: ImageStreamTag
+              namespace: "${TOOLS_WORKSPACE}"
+              name: mender-elasticsearch-stream:${IMAGESTREAM_TAG}
+
+  # Volume Claims
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels:
+        app: mender
+        subapp: mender-conductor
+      name: mender-redis-pv-claim
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: ${REDIS_VOLUME_CAPACITY}
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels:
+        app: mender
+        subapp: mender-conductor
+      name: mender-elasticsearch-pv-claim
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: ${ELASTICSEARCH_VOLUME_CAPACITY}
+
+parameters:
+  - description: The tag for image streams (i.e. dev/prod)
+    name: IMAGESTREAM_TAG
+    required: true
+  - description: The namespace of the image streams
+    name: TOOLS_WORKSPACE
+    required: true
+  - description: Size of PersistentVolumeClaim used to persist mender-redis (example 5Gi, 250Mi, etc).
+    name: REDIS_VOLUME_CAPACITY
+    required: true
+    value: "250Mi"
+  - description: Size of PersistentVolumeClaim used to persist mender-elasticsearch (example 5Gi, 250Mi, etc).
+    name: ELASTICSEARCH_VOLUME_CAPACITY
+    required: true
+    value: "250Mi"

--- a/mender/openshift/templates/mender-frontend-deployment-template.yaml
+++ b/mender/openshift/templates/mender-frontend-deployment-template.yaml
@@ -1,0 +1,276 @@
+kind: Template
+apiVersion: v1
+labels:
+  template: "mender-frontend-deployment" 
+  app: mender
+  subapp: mender-frontend
+metadata:
+  name: mender-frontend-deployment
+objects:
+
+  # mender api-gateway
+  ## serves as an entrypoint for all HTTP communication with Mender. 
+  ## Its main responsibility is the proxying of requests to Mender services, 
+  ## while rewriting URLs from a public API scheme to an internal one
+  ### https://github.com/mendersoftware/mender-api-gateway-docker
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        service: mender-api-gateway
+        app: mender
+        subapp: mender-frontend
+      name: mender-api-gateway
+    spec:
+      type: NodePort
+      ports:
+      - name: "api-gateway-port-mapping"
+        port: 443 
+        protocol: TCP
+        targetPort: 8443
+      selector:
+        service: mender-api-gateway
+        app: mender
+    status:
+      loadBalancer: {}
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: "The gatway through which the outside world communciates with Mender"
+        template.alpha.openshift.io/wait-for-ready: "true" #?
+      name: mender-api-gateway
+      labels:
+        app: mender
+        subapp: mender-frontend
+    spec:
+      replicas: 1
+      selector:
+        app: mender
+        service: mender-api-gateway
+      strategy:
+        type: Rolling
+        rollingParams:
+          updatePeriodSeconds: 1
+          intervalSeconds: 1
+          timeoutSeconds: 240
+          maxSurge: 2
+          maxUnavailable: 1
+        resources: {}
+        activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app: mender
+            subapp: mender-frontend
+            service: mender-api-gateway
+        spec:
+          containers:
+            - name: mender-api-gateway
+              image: " "
+              env:
+                - name: ALLOWED_HOSTS
+                  value: ${API_GATEWAY_ROUTE_HOSTNAME}
+              ports:
+                - containerPort: 8443
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                successThreshold: 1
+                tcpSocket:
+                  port: 8443
+                timeoutSeconds: 3
+              livenessProbe:
+                failureThreshold: 3
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                successThreshold: 1
+                tcpSocket:
+                  port: 8443
+                timeoutSeconds: 3
+              terminationMessagePath: "/dev/termination-log"
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          schedulerName: default-scheduler
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: name
+                        operator: In
+                        values:
+                          - mender-api-gateway
+                  topologyKey: kubernetes.io/hostname
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - mender-api-gateway
+            from:
+              kind: ImageStreamTag
+              namespace: "${TOOLS_WORKSPACE}"
+              name: mender-api-gateway-stream:${IMAGESTREAM_TAG}
+
+
+  # mender gui
+  ## webpage for interacting with Mender application
+  ### https://github.com/mendersoftware/gui
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: mender-gui
+      labels:
+        app: mender
+        subapp: mender-frontend
+    spec:
+      ports:
+      - port: 80
+        protocol: TCP
+        targetPort: 8080
+      selector:
+        service: mender-gui
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: "The gui service which provides the web interface"
+        template.alpha.openshift.io/wait-for-ready: "true" #?
+      name: mender-gui
+      labels:
+        app: mender
+        subapp: mender-frontend
+    spec:
+      replicas: 1
+      selector:
+        app: mender
+        service: mender-gui
+      strategy:
+        type: Rolling
+        rollingParams:
+          updatePeriodSeconds: 1
+          intervalSeconds: 1
+          timeoutSeconds: 300
+          maxSurge: 2
+          maxUnavailable: 1
+        resources: {}
+        activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app: mender
+            service: mender-gui
+        spec:
+          containers:
+            - name: mender-gui
+              image: " "
+              env:
+                - name: GATEWAY_IP
+                  value: ${API_GATEWAY_ROUTE_HOSTNAME}
+                - name: GATEWAY_PORT
+                  value: ${API_GATEWAY_MAPPED_PORT}
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
+              # readinessProbe:
+              #   failureThreshold: 3
+              #   initialDelaySeconds: 600
+              #   periodSeconds: 10
+              #   successThreshold: 1
+              #   tcpSocket:
+              #     port: 8080
+              #   timeoutSeconds: 3
+              # livenessProbe:
+              #   failureThreshold: 3
+              #   initialDelaySeconds: 600
+              #   periodSeconds: 10
+              #   successThreshold: 1
+              #   tcpSocket:
+              #     port: 8080
+              #   timeoutSeconds: 3
+              terminationMessagePath: "/dev/termination-log"
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 1000m
+                  memory: 512Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1024Mi
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          schedulerName: default-scheduler
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: name
+                        operator: In
+                        values:
+                          - mender-gui
+                  topologyKey: kubernetes.io/hostname
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - mender-gui
+            from:
+              kind: ImageStreamTag
+              namespace: "${TOOLS_WORKSPACE}"
+              name: mender-gui-stream:${IMAGESTREAM_TAG}
+
+  # Routes
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      name: mender-api-gateway-route
+      labels:
+        app: mender
+        subapp: mender-frontend
+    spec:
+      host: ${API_GATEWAY_ROUTE_HOSTNAME}
+      port:
+        targetPort: api-gateway-port-mapping
+      to:
+        kind: Service
+        name: mender-api-gateway
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+
+parameters:
+  - description: The tag for image streams (i.e. dev/prod)
+    name: IMAGESTREAM_TAG
+    required: true
+  - description: The hostname mapped to the Mender-Gateway-API route
+    name: API_GATEWAY_ROUTE_HOSTNAME
+    value: mender.pathfinder.gov.bc.ca
+    required: true
+  - description: The port the api-gateway is using
+    name: API_GATEWAY_MAPPED_PORT
+    value: "443"
+  - description: The namespace of the image streams
+    name: TOOLS_WORKSPACE
+    required: true

--- a/mender/openshift/templates/mender-image-build-template.yaml
+++ b/mender/openshift/templates/mender-image-build-template.yaml
@@ -1,0 +1,501 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: mender-build
+  annotations:
+    description: "Build stage for all Mender application components."
+    tags: queue-management,mender
+    #iconClass: icon-python
+labels:
+  template: mender-image-build
+parameters:
+  - name: INTEGRATION_VERSION
+    displayName: Mender-Integration git repo version
+    description: Version number for Mender-Integration git repo. This is used to download some specific config files for setup.
+    value: "1.7.0"
+  - name: API_GATEWAY_VERSION
+    displayName: Mender-API-Gateway version
+    description: Version number for the Mender-API-Gateway Docker image.
+    value: "1.6"
+  - name: GUI_VERSION
+    displayName: Mender-GUI version
+    description: Version number for the Mender-GUI Docker image.
+    value: "1.7"
+  - name: GUI_VERSION
+    displayName: Mender-GUI version
+    description: Version number for the Mender-GUI Docker image.
+    value: "1.7"
+  - name: USERADM_VERSION
+    displayName: Mender-Useradm version
+    description: Version number for the Mender-Useradm Docker image.
+    value: "1.7"
+  - name: INVENTORY_VERSION
+    displayName: Mender-Inventory version
+    description: Version number for the Mender-Inventory Docker image.
+    value: "1.5"
+  - name: DEPLOYMENTS_VERSION
+    displayName: Mender-Deployments version
+    description: Version number for the Mender-Deployments Docker image.
+    value: "1.6"
+  - name: DEVICEAUTH_VERSION
+    displayName: mender-device-auth version
+    description: Version number for the mender-device-auth Docker image.
+    value: "1.7"
+  - name: MONGO_VERSION
+    displayName: MongoDB version
+    description: Version number for the MongoDB Docker image.
+    value: "3.6"
+  - name: CONDUCTOR_VERSION
+    displayName: Mender-Conductor version
+    description: Version number for the Mender-Conductor Docker image.
+    value: "1.2"
+  - name: ELASTICSEARCH_VERSION
+    displayName: Mender-Elasticsearch version
+    description: Version number for the Mender-Elasticsearch Docker image. It's an official image from Dockerhub.
+    value: "5-alpine"
+  - name: REDIS_VERSION
+    displayName: Mender-Redis version
+    description: Version number for the Mender-Redis Docker image. It's an official image from Dockerhub.
+    value: "5-alpine3.8"
+
+objects:
+  # mender-api-gateway custom image build
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-api-gateway-stream
+      annotations:
+        description: "The mender-api-gateway image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-api-gateway-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM mendersoftware/api-gateway
+
+          # delete port 80 call
+          RUN sed -i 's/listen 80/listen 8080/g' /usr/local/openresty/nginx/conf/nginx.conf
+          
+          # adjust nginx config for correct ports and remove ssl
+          RUN sed -i 's/listen 443 ssl http2/listen 8443/g' /usr/local/openresty/nginx/conf/nginx.conf
+          RUN sed -i 's/ssl_/# ssl_/g' /usr/local/openresty/nginx/conf/nginx.conf
+
+          # unclear WHY this needs to happen but if you don't remove it you can't login
+          RUN sed -i 's/set $origin_valid 0/set $origin_valid 1/g' /usr/local/openresty/nginx/conf/nginx.conf
+          
+          # the container needs to believe there are these files, even if we don't use them
+          RUN mkdir -p /var/www/mendersoftware/cert
+          RUN touch /var/www/mendersoftware/cert/cert.crt
+          RUN touch /var/www/mendersoftware/cert/private.key
+
+          # allow non-ROOT users to use these directories
+          RUN chmod 0777 -R /usr/local/openresty
+          RUN chmod 0777 -R /var/run/
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: mendersoftware/api-gateway:${API_GATEWAY_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-api-gateway-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0
+
+  # mender-gui custom image build
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-gui-stream
+      annotations:
+        description: "The mender-gui image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-gui-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM mendersoftware/gui
+          RUN sed -i 's/-p 80/-p 8080/g' /entrypoint.sh
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: mendersoftware/gui:${GUI_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-gui-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0
+
+  # mender-useradm existing image to stream
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-useradm-stream
+      annotations:
+        description: "The mender-useradm image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-useradm-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM mendersoftware/useradm
+          RUN chmod 0777 -R /etc/useradm/
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: mendersoftware/useradm:${USERADM_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-useradm-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0
+
+  # mender-inventory existing image to stream
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-inventory-stream
+      annotations:
+        description: "The mender-inventory image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-inventory-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM mendersoftware/inventory
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: mendersoftware/inventory:${INVENTORY_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-inventory-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0
+
+  # mender-deployments existing image to stream
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-deployments-stream
+      annotations:
+        description: "The mender-deployments image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-deployments-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM mendersoftware/deployments
+          RUN chmod 0777 -R /etc/ssl/certs/
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: mendersoftware/deployments:${DEPLOYMENTS_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-deployments-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0
+
+  # mender-device-auth existing image to stream
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-device-auth-stream
+      annotations:
+        description: "The mender-device-auth image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-device-auth-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM mendersoftware/deviceauth
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: mendersoftware/deviceauth:${DEVICEAUTH_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-device-auth-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0
+
+  # mongodb existing image to stream
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-mongodb-stream
+      annotations:
+        description: "The mongodb image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-mongodb-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM openshift/mongodb
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: docker-registry.default.svc:5000/openshift/mongodb:${MONGO_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-mongodb-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0
+
+  # mender-conductor existing image to stream
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-conductor-stream
+      annotations:
+        description: "The mender-conductor image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-conductor-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM mendersoftware/mender-conductor
+          # Grab config file from Mender-Integration git repo
+          ADD https://raw.githubusercontent.com/mendersoftware/integration/${INTEGRATION_VERSION}/conductor/server/config/config.properties /app/config/
+          RUN chmod 0777 -R /app/config/
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: mendersoftware/mender-conductor:${CONDUCTOR_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-conductor-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0
+
+  # mender-elasticsearch existing image to stream
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-elasticsearch-stream
+      annotations:
+        description: "The mender-elasticsearch image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-elasticsearch-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM elasticsearch
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: elasticsearch:${ELASTICSEARCH_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-elasticsearch-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0
+
+  # mender-redis existing image to stream
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: mender-redis-stream
+      annotations:
+        description: "The mender-redis image."
+      labels:
+        app: mender
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: mender-redis-build
+      labels:
+        app: mender
+    spec:
+      triggers:
+        - type: ImageChange
+          imageChange: {}
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM redis
+          # Grab config file from Mender-Integration git repo
+          RUN mkdir -p /etc/redis/ 
+          ADD https://raw.githubusercontent.com/mendersoftware/integration/${INTEGRATION_VERSION}/conductor/redis/redis.conf /etc/redis/
+          RUN mkdir -p /redis/
+          ADD https://raw.githubusercontent.com/mendersoftware/integration/${INTEGRATION_VERSION}/conductor/redis/entrypoint.sh /redis/
+          RUN chmod 0777 -R /etc/redis/ /redis/
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: redis:${REDIS_VERSION}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: mender-redis-stream:latest
+      resources:
+          limits:
+            cpu: "1"
+    status:
+      lastVersion: 0

--- a/mender/openshift/templates/mender-mongodb-deployment-template.yaml
+++ b/mender/openshift/templates/mender-mongodb-deployment-template.yaml
@@ -1,0 +1,171 @@
+kind: Template
+apiVersion: v1
+labels:
+  template: "mender-mongodb-deployment" 
+  app: mender
+  subapp: mender-mongodb
+metadata:
+  name: mender-mongodb-deployment
+objects:  
+  # MongoDB 
+  ## used by deployments, inventory, deviceauth, useradm
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: mender-mongodb
+      labels:
+        app: mender
+        subapp: mender-mongodb
+    spec:
+      ports:
+      - port: 27017
+        protocol: TCP
+      selector:
+        service: mender-mongodb
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: "The mongodb used by deviceauth, useradm, inventory, and deployments."
+        template.alpha.openshift.io/wait-for-ready: "true" #?
+      name: mender-mongodb
+      labels:
+        app: mender
+        subapp: mender-mongodb
+    spec:
+      replicas: 1
+      selector:
+        app: mender
+        service: mender-mongodb
+      strategy:
+        type: Rolling
+        rollingParams:
+          updatePeriodSeconds: 1
+          intervalSeconds: 1
+          timeoutSeconds: 120
+          maxSurge: 2
+          maxUnavailable: 1
+        resources: {}
+        activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app: mender
+            service: mender-mongodb
+        spec:
+          containers:
+            - name: mender-mongodb
+              image: " "
+              env:
+                - name: MONGODB_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: mender-mongodb-secret
+                      key: mongodb-password
+              readinessProbe:
+                failureThreshold: 3
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                successThreshold: 1
+                tcpSocket:
+                  port: 27017
+                timeoutSeconds: 3
+              livenessProbe:
+                failureThreshold: 3
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                successThreshold: 1
+                tcpSocket:
+                  port: 27017
+                timeoutSeconds: 3
+              volumeMounts:
+                - name: mender-mongodb-pv-claim
+                  mountPath: /data/db
+              terminationMessagePath: "/dev/termination-log"
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          schedulerName: default-scheduler
+          volumes:
+            - name: mender-mongodb-pv-claim
+              persistentVolumeClaim:
+                claimName: mender-mongodb-pv-claim
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: name
+                        operator: In
+                        values:
+                          - mongodb
+                  topologyKey: kubernetes.io/hostname
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - mender-mongodb
+            from:
+              kind: ImageStreamTag
+              namespace: "${TOOLS_WORKSPACE}"
+              name: mender-mongodb-stream:${IMAGESTREAM_TAG}
+
+  # DB Volume Claim
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels:
+        app: mender
+        subapp: mender-mongodb
+      name: mender-mongodb-pv-claim
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: ${MONGO_VOLUME_CAPACITY}
+
+  # DB Configuration Secrets
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: mender-mongodb-secret
+      labels:
+        app: mender
+        subapp: mender-mongodb
+      annotations:
+        template.openshift.io/base64-expose-mongodb-username: "{.data['mongodb-username']}"
+        template.openshift.io/base64-expose-mongodb-password: "{.data['mongodb-password']}"
+    type: Opaque
+    stringData:
+      mongodb-username: "admin"
+      mongodb-password: "${MONGODB_ADMIN_PASSWORD}"
+
+parameters:
+  - description: The tag for image streams (i.e. dev/prod)
+    name: IMAGESTREAM_TAG
+    required: true
+  - description: The namespace of the image streams
+    name: TOOLS_WORKSPACE
+    required: true
+  - description: MongoDB admin password--automatically generated and stored as a sceret.
+    name: MONGODB_ADMIN_PASSWORD
+    required: true
+    from: '[a-zA-Z0-9]{16}'
+    generate: expression
+  - description: Size of PersistentVolumeClaim used to persist Mongodb (example 5Gi, 250Mi, etc).
+    name: MONGO_VOLUME_CAPACITY
+    required: true
+    value: "10Gi"


### PR DESCRIPTION
This commit provides multiple templates for launching the Mender application in OpenShift. This includes BuildConfigs for generating all of the ImageStreams necessary for running the application.

Please be advised: some of the BuildConfigs modify the underlying Docker Images which ship from Mender. Most of these modifications are to modify directory permissions to allow non-root users. However, some of the modifications do alter configurations of the underlying micro-applications (e.g. `mender-api-gateway`). In instances where the underlying micro-application configuration has been modified, great care has been taken to NOT modify applciation code so as to not mess with future updates, **however** some of the modifications use the `sed` and will not necessarilly fail if upstream files change. **THEREFORE** please take great care when upgrading to newer releases of the underlying Docker Images.

In order to increase flexibility within the configration, the application has been split into multiple templates along logical boundaries within the application, specifically:

* mender-mongodb (mender-mongodb)
* mender-conductor (mender-conductor, mender-redis, mender-elasticsearch)
* mender-components (mender-useradm, mender-deployments, mender-user-auth, mender-inventory)
* mender-frontend (mender-api-gateway, mender-gui)

Each of these templates also uses a label--`subapp`--to define those groups of objects. This makes deleting and scaling (with the `-l subapp=<subapp name> flag) easier for these groups.

The `./mender/openshift/mender_deployment_quickstart.md` file provides the quickest way to launch the application.

---
Additional Information:
* None of the DeploymentConfigs have been tuned (CPU/Memory usage). This should be done as the project is put under load.
* Some of the health monitoring for DeploymentConfigs have been commented out. They were causing failures. This should eventually be dealt with...